### PR TITLE
Kill orphans

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,15 +76,6 @@ mod tests {
   }
 
   #[test]
-  fn sys_gets_tasks() {
-    let tasks = Sys::tasks();
-    assert!(!&tasks.is_empty());
-
-    let tasks_ref = &mut tasks.into_iter();
-    assert!(tasks_ref.any(|s| s.contains("cargo")));
-  }
-
-  #[test]
   fn gets_priority_processes() {
     let mut sys = Sys {
       system: sysinfo::System::new_all(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,22 +66,12 @@ mod tests {
   }
 
   #[test]
-  fn sys_gets_cargo_process() {
-    let mut sys = Sys {
-      system: sysinfo::System::new_all(),
-    };
-
-    let ps = sys.processes_matching("cargo");
-    assert!(!ps.is_empty());
-  }
-
-  #[test]
   fn gets_priority_processes() {
     let mut sys = Sys {
       system: sysinfo::System::new_all(),
     };
-    let (_ps1, ps2) = &mut sys.priority_processes();
-    assert!(!ps2.is_empty());
+    let pids = &mut sys.fetch_pids();
+    assert!(!pids.mining.is_empty());
   }
 
   #[test]

--- a/src/mining.rs
+++ b/src/mining.rs
@@ -33,7 +33,7 @@ impl Mining {
 
   pub fn kill(sys: &mut Sys, pids: Vec<Pid>) {
     let kill_pids = if pids.is_empty() {
-      Sys::pids(sys.priority_processes().1)
+      sys.fetch_pids().mining
     } else {
       pids
     };

--- a/src/rig.rs
+++ b/src/rig.rs
@@ -48,24 +48,12 @@ impl Rig {
 
     match (pids.gaming.is_empty(), pids.mining.is_empty()) {
       (true, true) => Self::Idle,
+      (false, true) => Self::Gaming,
       (true, false) => Self::Mining.on_idle(&env.gpu, || Mining::kill(&mut env.sys, vec![]), true),
       (false, false) => Self::Conflict {
         gaming: pids.gaming,
         mining: pids.mining,
       },
-      (false, true) => Self::Gaming.on_idle(
-        &env.gpu,
-        || {
-          println!(
-            "{:?}",
-            pids
-              .gaming
-              .into_iter()
-              .map(|p| Sys::pretty_proc(env.sys.lookup(p).unwrap(), "gaming"))
-          )
-        },
-        false,
-      ),
     }
   }
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,5 +1,4 @@
 use std::collections::hash_map::Values;
-use std::process::Command;
 use std::str;
 
 use sysinfo::{Pid, Process, ProcessExt, SystemExt};
@@ -17,11 +16,9 @@ pub struct Pids {
 }
 
 impl Sys {
-  pub fn tasks() -> Vec<String> {
-    let output = Command::new("tasklist.exe").output().unwrap();
-    let stdout = output.stdout;
-    let out = str::from_utf8(&stdout).unwrap();
-    out.split('\n').map(str::to_string).collect()
+  fn refresh(&mut self) -> &mut Self {
+    self.system.refresh_processes();
+    self
   }
 
   pub fn fetch_pids(&mut self) -> Pids {
@@ -59,53 +56,6 @@ impl Sys {
       gaming: p1,
       mining: p2,
     }
-  }
-
-  pub fn pids(ps: Vec<&Process>) -> Vec<Pid> {
-    ps.into_iter().map(|p| p.pid()).collect()
-  }
-
-  pub fn processes(&mut self) -> Values<Pid, Process> {
-    self.refresh().system.processes().values()
-  }
-
-  pub fn processes_matching(&mut self, needle: &str) -> Vec<&Process> {
-    self
-      .processes()
-      .filter(|p| p.name().to_lowercase().contains(needle))
-      .collect()
-  }
-
-  pub fn mining_pids(&mut self) -> Vec<Pid> {
-    Self::pids(self.priority_processes().1)
-  }
-
-  pub fn gaming_pids(&mut self) -> Vec<Pid> {
-    Self::pids(self.priority_processes().0)
-  }
-
-  pub fn priority_processes(&mut self) -> (Vec<&Process>, Vec<&Process>) {
-    let mut p1 = vec![];
-    let mut p2 = vec![];
-
-    let gp1s = config::json().gpu_p1;
-    let gp2s = config::json().gpu_p2;
-
-    for p in self.refresh().system.processes().values() {
-      if gp1s.contains(&p.name().to_owned()) {
-        println!("{}", Self::pretty_proc(p, "p1 gaming"));
-        p1.push(p);
-      } else if gp2s.contains(&p.name().to_owned()) {
-        println!("{}", Self::pretty_proc(p, "p2 mining"));
-        p2.push(p);
-      }
-    }
-    (p1, p2)
-  }
-
-  pub fn refresh(&mut self) -> &mut Self {
-    self.system.refresh_processes();
-    self
   }
 
   pub fn lookup(&mut self, pid: Pid) -> Option<&Process> {


### PR DESCRIPTION
* hashman now kills all children of any process p that it finds matching the config.gpu_p{x} fields
* this does not kill children of children, but NiceHash is only one layer deep in its process spawn behavior 